### PR TITLE
Add queen related restrictions

### DIFF
--- a/src/app.pl
+++ b/src/app.pl
@@ -113,9 +113,9 @@ updateCounter(Color, Type):-
 
 
 selectBugForPlacement(Color, Type):-
+    clearPlaceableCells,
     board:currentColor(Color),
-    board:availableBug(Color, Type, Cnt),
-    Cnt > 0,
+    board:placeableByColor(Color, Type),
     retractall(selectedBug(_,_,_)),
     assertz(selectedBug(Color, Type, place)),
     drawPlaceableCells(Color).


### PR DESCRIPTION
Adds a turn count to check the queen restriction (see currentTurn/2).
Adds a new predicate to restrict the placementet (see placeableByColor/2).
Modifies the predicate canBeMoved to check for the existence of the queen (see canBeMoved/3).
This merge resolves #14. 